### PR TITLE
LUT-32930 : Fix archive daemon to delete ressources with status archived

### DIFF
--- a/src/java/fr/paris/lutece/plugins/workflow/modules/archive/daemon/ArchiveDaemon.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/archive/daemon/ArchiveDaemon.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 
 import org.apache.commons.collections.CollectionUtils;
 
+import fr.paris.lutece.plugins.workflow.modules.archive.ArchivalType;
 import fr.paris.lutece.plugins.workflow.modules.archive.business.ArchiveConfig;
 import fr.paris.lutece.plugins.workflow.modules.archive.service.ArchiveService;
 import fr.paris.lutece.plugins.workflow.modules.archive.service.IArchiveService;
@@ -95,6 +96,11 @@ public class ArchiveDaemon extends Daemon
         }
     }
 
+    /**
+     * Method to select the valid ressources to process the archive task.
+     * @param action Automatic Archivage task linked to a state
+     * @param wf the workflow
+     */
     private void processAction( Action action, Workflow wf )
     {
         List<ITask> listTasks = getListTaskByIdActionAndTaskType( action.getId( ), "taskTypeArchive", Locale.getDefault( ) );
@@ -102,7 +108,8 @@ public class ArchiveDaemon extends Daemon
         if ( CollectionUtils.isNotEmpty( listTasks ) )
         {
             ResourceWorkflowFilter filt = new ResourceWorkflowFilter( );
-            filt.setListIdStateBefore( action.getListIdStateBefore( ) );
+            List<Integer> listIdStateToTreat = buildListIdStateToTreat(action, listTasks);
+            filt.setListIdStateBefore( listIdStateToTreat);
             filt.setIdWorkflow( wf.getId( ) );
 
             List<ResourceWorkflow> listResource = _resourceWorkflowService.getListResourceWorkflowByFilter( filt );
@@ -123,6 +130,32 @@ public class ArchiveDaemon extends Daemon
                 }
             }
         }
+    }
+
+    /**
+     * Build the list of the states totreat by the dameon archive
+     * Example: [Validated, Canceled, Archived - Deleted]
+     * @param action the action to process
+     * @param listTasks the list of tasks to process
+     * @return the list of the states to treat
+     */
+    private List<Integer> buildListIdStateToTreat(Action action, List<ITask> listTasks) {
+        List<Integer> listIdStateToTreat =  new ArrayList<>();
+
+        // Add source states configured on the archive action.
+        listIdStateToTreat.addAll( action.getListIdStateBefore( ) );
+        // Add target archive states for DELETE tasks
+        for ( ITask task : listTasks)
+        {
+            ArchiveConfig config = _archiveService.loadConfig( task );
+            if ( config != null
+                    && ArchivalType.DELETE.equals( config.getTypeArchival( ) )
+                    && !listIdStateToTreat.contains( config.getNextState( ) ) )
+            {
+                listIdStateToTreat.add( config.getNextState( ) );
+            }
+        }
+        return listIdStateToTreat;
     }
 
     private List<ITask> getListTaskByIdActionAndTaskType( int nIdAction, String taskType, Locale locale )

--- a/src/java/fr/paris/lutece/plugins/workflow/modules/archive/service/ArchiveService.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/archive/service/ArchiveService.java
@@ -42,6 +42,7 @@ import java.util.Locale;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import fr.paris.lutece.plugins.workflow.modules.archive.ArchivalType;
 import fr.paris.lutece.plugins.workflow.modules.archive.IResourceArchiver;
 import fr.paris.lutece.plugins.workflow.modules.archive.WorkflowResourceArchiver;
 import fr.paris.lutece.plugins.workflow.modules.archive.business.ArchiveConfig;
@@ -139,6 +140,11 @@ public class ArchiveService implements IArchiveService
     @Override
     public boolean isResourceUpForArchival( ResourceWorkflow resourceWorkflow, ArchiveConfig config )
     {
+        if ( ArchivalType.DELETE.equals( config.getTypeArchival( ) ) && resourceWorkflow.getState( ) != null
+                && resourceWorkflow.getState( ).getId( ) == config.getNextState( ) )
+        {
+            return true;
+        }
         if ( config.getDelayArchival( ) <= 0 )
         {
             return true;


### PR DESCRIPTION
**Deleting ressources with status Archived**

There are appointments with the “Archived” status that shouldn't exist because they should have been deleted. 

This issue was fixed in PR https://github.com/lutece-secteur-public/gru-plugin-appointment/pull/205

However, the daemon must still take these statuses into account during automatic deletion to potentially clean up a database that is in an inconsistent state. This has been added here: 

<img width="1919" height="1633" alt="image" src="https://github.com/user-attachments/assets/9fde8c61-9785-4232-9734-f5b2627a7966" />

We’re also adding support for these statuses to the method that determines whether a resource should be archived

<img width="1831" height="306" alt="image" src="https://github.com/user-attachments/assets/681b5e22-79d2-4888-a150-dc9485b573f7" />


